### PR TITLE
Use sysctl hw.memsize instead of sysctl -a | grep

### DIFF
--- a/memory-bar.widget/index.coffee
+++ b/memory-bar.widget/index.coffee
@@ -1,4 +1,4 @@
-command: "memory_pressure && sysctl -a | grep memsize"
+command: "memory_pressure && sysctl hw.memsize"
 
 refreshFrequency: 2000
 

--- a/memory-bar.widget/index.coffee
+++ b/memory-bar.widget/index.coffee
@@ -1,4 +1,4 @@
-command: "memory_pressure && sysctl hw.memsize"
+command: "memory_pressure && sysctl -n hw.memsize"
 
 refreshFrequency: 2000
 
@@ -141,7 +141,7 @@ update: (output, domEl) ->
   activePages = lines[12].split(": ")[1]
   wiredPages = lines[16].split(": ")[1]
 
-  totalBytes = lines[28].split(" = ")[1]
+  totalBytes = lines[28]
   $(domEl).find(".total").text usageFormat(totalBytes / 1024 / 1024)
 
   updateStat 'free', freePages, totalBytes


### PR DESCRIPTION
The usage of `sysctl hw.memsize` saves us the call of grep.

Also (at least on Yosemite), `sysctl -a` causes a `kernel: AudioSysctl: (0)` message to be written to the system logs on each widget update, so this issue gets eliminated in the same change.

Also in Yosemite the output format of `sysctl` seems to have changed from "Key = Value" to "Key: Value". By using the `-n` option, the key isn't printed anymore and so helps with this issue, too.

Cheers and thank you for this beautiful widget!
:octocat: Jérôme

Fixes #1 
Fixes #2
